### PR TITLE
GTest and GMake as external projects

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,37 +1,11 @@
 set(CTEST_OUTPUT_ON_FAILURE TRUE)
+INCLUDE(External.cmake)
 
-find_package (GTest REQUIRED)
-
-# find Gmock library
-find_library(GMOCK_LIBRARIES gmock
-    HINTS
-    $ENV{GMOCK_ROOT}
-    ${GMOCK_ROOT}
-    $ENV{GMOCK_ROOT}/make
-    ${GMOCK_ROOT}/make
-)
-
-find_path(GMOCK_INCLUDE_DIR gmock/gmock.h
-    HINTS
-    $ENV{GMOCK_ROOT}/include
-    ${GMOCK_ROOT}/include
-)
-
-if(NOT DEFINED GMOCK_INCLUDE_DIR OR NOT DEFINED GMOCK_LIBRARIES)
-    message(SEND_ERROR "gmock not found")
-endif()
-
-include_directories(
-    ${GTEST_INCLUDE_DIRS}
-    ${GMOCK_INCLUDE_DIRS}
-)
-
+INCLUDE_DIRECTORIES(${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR})
+LINK_DIRECTORIES(${GTEST_LIB_DIR} ${GMOCK_LIB_DIR})
 file(GLOB test_sources *.cc)
 add_executable(test_zmqcpp ${test_sources})
 
-target_link_libraries(test_zmqcpp
-    ${GTEST_BOTH_LIBRARIES}
-    ${GMOCK_BOTH_LIBRARIES}
-    zmq
-)
-gtest_add_tests(test_zmqcpp "--gtest_output=xml" ${test_sources})
+ADD_DEPENDENCIES(test_zmqcpp googletest googlemock)
+target_link_libraries(test_zmqcpp zmq gtest gmock)
+add_test(testzmq test_zmqcpp --gtest_output=xml)

--- a/test/External.cmake
+++ b/test/External.cmake
@@ -52,3 +52,4 @@ SET(GMOCK_DIR ${source_dir})
 SET(GMOCK_INCLUDE_DIR ${source_dir}/include)
 ExternalProject_Get_Property(googlemock binary_dir)
 SET(GMOCK_LIB_DIR "${binary_dir}")
+

--- a/test/External.cmake
+++ b/test/External.cmake
@@ -1,0 +1,54 @@
+# Enable ExternalProject CMake module
+INCLUDE(ExternalProject)
+
+# main directory for external projects
+SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/ThirdParty)
+
+# GTest external project
+ExternalProject_Add(
+    googletest
+    SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk/
+    TIMEOUT 10
+    # Force separate output paths for debug and release builds to allow easy
+    # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
+    #CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
+    #           -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
+    #           -Dgtest_force_shared_crt=ON
+    # Disable update
+    UPDATE_COMMAND ""
+    # Disable install step
+    INSTALL_COMMAND ""
+    # Wrap download, configure and build steps in a script to log output
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON)
+
+ExternalProject_Get_Property(googletest source_dir)
+SET(GTEST_DIR ${source_dir})
+SET(GTEST_INCLUDE_DIR ${source_dir}/include)
+ExternalProject_Get_Property(googletest binary_dir)
+SET(GTEST_LIB_DIR "${binary_dir}")
+
+# GMock external project
+ExternalProject_Add(
+    googlemock
+    SVN_REPOSITORY http://googlemock.googlecode.com/svn/trunk/
+    TIMEOUT 10
+    # Force separate output paths for debug and release builds to allow easy
+    # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
+    #CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
+    #           -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
+    # Disable svn update (for now)
+    UPDATE_COMMAND ""
+    # Disable install step
+    INSTALL_COMMAND ""
+    # Wrap download, configure and build steps in a script to log output
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON)
+
+ExternalProject_Get_Property(googlemock source_dir)
+SET(GMOCK_DIR ${source_dir})
+SET(GMOCK_INCLUDE_DIR ${source_dir}/include)
+ExternalProject_Get_Property(googlemock binary_dir)
+SET(GMOCK_LIB_DIR "${binary_dir}")


### PR DESCRIPTION
Hey,

I modified the CMake files to use GTest and GMake as ExternalProject instead of relying on global dependencies for them, as per Google's recommendation.
